### PR TITLE
Migrate from libkv to valkeyrie library

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,17 +2,16 @@
 
 
 [[projects]]
+  branch = "master"
+  name = "github.com/abronan/valkeyrie"
+  packages = ["store","store/mock"]
+  revision = "063d875e3c5fd734fa2aa12fac83829f62acfc70"
+
+[[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/docker/libkv"
-  packages = ["store","store/mock"]
-  revision = "5e4bb288a9a74320bb03f5c18d6bdbab0d8049de"
-  source = "github.com/abronan/libkv"
 
 [[projects]]
   name = "github.com/pmezard/go-difflib"
@@ -35,6 +34,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8ed2b0a77715c1cffc6a65871c5da460d264f6f8164453d05fc77f5c883236ae"
+  inputs-digest = "9dca6faf9d505e175319017eae3b39c73b0b9e7045bc3b7016c09af8756efe88"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -20,11 +20,10 @@
 #  name = "github.com/x/y"
 #  version = "2.4.0"
 
-
-[[constraint]]
-  name = "github.com/docker/libkv"
-  source = "github.com/abronan/libkv"
-
 [[constraint]]
   name = "github.com/stretchr/testify"
   version = "1.1.4"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/abronan/valkeyrie"

--- a/candidate.go
+++ b/candidate.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/docker/libkv/store"
+	"github.com/abronan/valkeyrie/store"
 )
 
 const (

--- a/candidate_test.go
+++ b/candidate_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	libkvmock "github.com/docker/libkv/store/mock"
+	libkvmock "github.com/abronan/valkeyrie/store/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/follower.go
+++ b/follower.go
@@ -3,7 +3,7 @@ package leadership
 import (
 	"errors"
 
-	"github.com/docker/libkv/store"
+	"github.com/abronan/valkeyrie/store"
 )
 
 // Follower can follow an election in real-time and push notifications whenever

--- a/follower_test.go
+++ b/follower_test.go
@@ -3,8 +3,8 @@ package leadership
 import (
 	"testing"
 
-	"github.com/docker/libkv/store"
-	libkvmock "github.com/docker/libkv/store/mock"
+	"github.com/abronan/valkeyrie/store"
+	libkvmock "github.com/abronan/valkeyrie/store/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )


### PR DESCRIPTION
Migrate from the `abronan/libkv` library to its new repository `abronan/valkeyrie`.